### PR TITLE
Include Exiv2::Error namespace

### DIFF
--- a/lib/imagemetainfomodel.cpp
+++ b/lib/imagemetainfomodel.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #include <exiv2/exif.hpp>
 #include <exiv2/image.hpp>
 #include <exiv2/iptc.hpp>
+#include <exiv2/error.hpp>
 
 // Local
 #ifdef HAVE_FITS


### PR DESCRIPTION
In error.hpp is not included, I get this error message:
```
/var/tmp/portage/kde-apps/gwenview-19.04.1/work/gwenview-19.04.1/lib/imagemetainfomodel.cpp: In member function ‘void Gwenview::ImageMetaInfoModelPrivate::fillExivGroup(const QModelIndex&, Gwenview::MetaInfoGroup*, const Container&)’:
/var/tmp/portage/kde-apps/gwenview-19.04.1/work/gwenview-19.04.1/lib/imagemetainfomodel.cpp:293:40: error: expected unqualified-id before ‘&’ token
  293 |             } catch (const Exiv2::Error& error) {
      |                                        ^
/var/tmp/portage/kde-apps/gwenview-19.04.1/work/gwenview-19.04.1/lib/imagemetainfomodel.cpp:293:40: error: expected ‘)’ before ‘&’ token
  293 |             } catch (const Exiv2::Error& error) {
      |                     ~                  ^
      |                                        )
/var/tmp/portage/kde-apps/gwenview-19.04.1/work/gwenview-19.04.1/lib/imagemetainfomodel.cpp:293:40: error: expected ‘{’ before ‘&’ token
/var/tmp/portage/kde-apps/gwenview-19.04.1/work/gwenview-19.04.1/lib/imagemetainfomodel.cpp:293:42: error: ‘error’ was not declared in this scope; did you mean ‘perror’?
  293 |             } catch (const Exiv2::Error& error) {
      |                                          ^~~~~
      |                                          perror
```